### PR TITLE
Updated Docs - Added Superuser & Automatic Seeding Data

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+website/src/pages/mapper/dev_guide/quickstart.mdx
+website/src/pages/mapper/deployment/azure/steps.mdx

--- a/website/src/pages/mapper/deployment/azure/steps.mdx
+++ b/website/src/pages/mapper/deployment/azure/steps.mdx
@@ -97,14 +97,14 @@ Select `Container Image` as the mode of deploying.
 **Tags**: Give name and value for the web app's tag, if needed.
 
 **Container Image**: A default image will be used as you create a function app. Therefore, after the app being deployed you must change this image by doing so:
-  <div>
-    1. Access the newly created Function app.
-    2. Under tab `Deployment`, choose `Deployment center`.
-    3. Choose `Private Registry` as Registry source.
-    4. Change Server URL to: `https://ghcr.io`.
-    5. Change Full Image Name and Tag to: `health-informatics-uon/carrot/workers:<tag>`. Look for available tags [here](https://github.com/Health-Informatics-UoN/carrot-mapper/pkgs/container/carrot%2Fworkers).
-    6. Save the Settings.
-  </div>
+
+- Access the newly created Function app.
+- Under tab `Deployment`, choose `Deployment center`.
+- Choose `Private Registry` as Registry source.
+- Change Server URL to: `https://ghcr.io`.
+- Change Full Image Name and Tag to: `health-informatics-uon/carrot/workers:<tag>`. Look for available tags [here](https://github.com/Health-Informatics-UoN/carrot-mapper/pkgs/container/carrot%2Fworkers).
+- Save the Settings.
+
 
 ### PostgreSQL Database
 
@@ -288,24 +288,17 @@ Navigate to `Environment variables` section under `Settings` of your Backend web
     2. Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
   </div>
 
-**The credentials will be applied after restarting the Backend app.**
 
 ---
 
-**Now, do the following steps:**
+**Now, do the following steps for creating the first instance:**
 
-1. **Restart your app for the environment variables to be applied**.
+  1. **Restart your app** for the environment variables to be applied.
 
-2. After that, Carrot will seed the app's database with the OMOP table and field names. 
+  2. **Access the Admin Panel** using the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
 
-3. Some **First Instances of Carrot** also need creating after the Backend app up and running. 
+  3. Then create first instance of the `Data partner`, `Dataset`, and `Project`.
 
-    **Follow these steps to create the first instances:**
-    <div>
-      1. Doing this by access the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
-
-      2. Then create first instance of the `Data partner`, `Dataset`, and `Project`.
-    </div>
 
 ### Frontend app
 

--- a/website/src/pages/mapper/deployment/azure/steps.mdx
+++ b/website/src/pages/mapper/deployment/azure/steps.mdx
@@ -257,49 +257,19 @@ Navigate to `Environment variables` section under `Settings` of your Backend web
       </Td>
     </Tr>
     <Tr>
-      <Td>`SUPERUSER_DEFAULT_USERNAME` `SUPERUSER_DEFAULT_EMAIL` `SUPERUSER_DEFAULT_PASSWORD`</Td>
+      <Td>`SUPERUSER_DEFAULT_USERNAME` `SUPERUSER_DEFAULT_PASSWORD` `SUPERUSER_DEFAULT_EMAIL` </Td>
       <Td>
-        Optional superuser credentials. Add these if you would like to setup custom credentials for Django superuser. Read more below.
+        Credentials required to create the first superuser in Carrot. Without these variables, no superuser will be created.
+        `SUPERUSER_DEFAULT_EMAIL` is defaulted to `user@carrot`.
       </Td>
     </Tr>
   </tbody>
 </Table>
 
-<div id="superuserCredentialsAzure">
-  <Callout type="warning">
-    **Before restarting the application, you need decide the method of superuser credentials setup**, which is using either **default** superuser credentials or **custom** superuser credentials.
-  </Callout>
-</div>
-
-
-- **Default superuser credentials**: By default, Carrot creates a superuser with the following credentials:
-  <div>
-    - Username: `admin`
-    - Password: `Password123!`
-    - Email: `user@carrot`
-  </div>
-
-  **If you wish to use the default superuser credentials**, you can skip the steps below.
-
-- **Custom superuser credentials**: If you wish to create a new super user with custom credentials, do the following:
-  <div>
-    1. Add three more environment variables below to the Backend app's `Environment Variables`:
-      <div>
-        ```
-          - SUPERUSER_DEFAULT_USERNAME : your_username
-          - SUPERUSER_DEFAULT_EMAIL : your_email
-          - SUPERUSER_DEFAULT_PASSWORD : your_password
-        ```
-      </div>
-    2. Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
-  </div>
-
-
----
 
 **Restart your app** for the environment variables to be applied, and then create the first instances in Carrot by the following steps:
 
-  1. **Access the Admin Panel** using the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
+  1. **Access the Admin Panel** using the URL: `<backend-URL>/admin/`, log in using the superuser credentials in the `Environment variables` section.
 
   2. Create first instance of `Data partner`, `Dataset`, and `Project`.
 

--- a/website/src/pages/mapper/deployment/azure/steps.mdx
+++ b/website/src/pages/mapper/deployment/azure/steps.mdx
@@ -256,24 +256,30 @@ Navigate to `Environment variables` section under `Settings` of your Backend web
         complex key for this. It is recommended to put this in the Key Vault.
       </Td>
     </Tr>
+    <Tr>
+      <Td>`SUPERUSER_DEFAULT_USERNAME` `SUPERUSER_DEFAULT_EMAIL` `SUPERUSER_DEFAULT_PASSWORD`</Td>
+      <Td>
+        Optional superuser credentials. Add these if you would like to setup custom credentials for Django superuser. Read more below.
+      </Td>
+    </Tr>
   </tbody>
 </Table>
 
-**Before restarting the application, you need decide the method of superuser credentials setup.**
 <div id="superuserCredentialsAzure">
   <Callout type="warning">
-    Either you use the **default superuser credentials** or **custom superuser credentials**.
+    **Before restarting the application, you need decide the method of superuser credentials setup**, which is using either **default** superuser credentials or **custom** superuser credentials.
   </Callout>
 </div>
-
-**If you wish to use the default superuser credentials**, you can **skip the setup for custom super user credentials** and use the **default credentials** to log in to the Django Admin Panel (see below).
 
 
 - **Default superuser credentials**: By default, Carrot creates a superuser with the following credentials:
   <div>
     - Username: `admin`
     - Password: `Password123!`
+    - Email: `user@carrot`
   </div>
+
+  **If you wish to use the default superuser credentials**, you can skip the steps below.
 
 - **Custom superuser credentials**: If you wish to create a new super user with custom credentials, do the following:
   <div>
@@ -291,13 +297,11 @@ Navigate to `Environment variables` section under `Settings` of your Backend web
 
 ---
 
-**Now, do the following steps for creating the first instance:**
+**Restart your app** for the environment variables to be applied, and then create the first instances in Carrot by the following steps:
 
-  1. **Restart your app** for the environment variables to be applied.
+  1. **Access the Admin Panel** using the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
 
-  2. **Access the Admin Panel** using the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
-
-  3. Then create first instance of the `Data partner`, `Dataset`, and `Project`.
+  2. Create first instance of `Data partner`, `Dataset`, and `Project`.
 
 
 ### Frontend app

--- a/website/src/pages/mapper/deployment/azure/steps.mdx
+++ b/website/src/pages/mapper/deployment/azure/steps.mdx
@@ -258,24 +258,50 @@ Navigate to `Environment variables` section under `Settings` of your Backend web
   </tbody>
 </Table>
 
-Restart your app for the environment variables to be applied.
+**Before restarting the application, you need decide the method of superuser credentials setup.**
+<div id="superuserCredentialsAzure">
+  <Callout type="warning">
+    Either you use the **default superuser credentials** or **custom superuser credentials**.
+  </Callout>
+</div>
 
-{/* TODO: Add more information about how to do the steps below locally */}
+**If you wish to use the default superuser credentials**, you can **skip the setup for custom super user credentials** and use the **default credentials** to log in to the Django Admin Panel (see below).
 
-After that, you need to seed the Carrot app database with the OMOP table and field names. For now, this can be done by connecting directly to your database either by local machine or through an environment, then run the command:
 
-```bash
-python manage.py loaddata mapping filetypes
-```
+- **Default superuser credentials**: By default, Carrot creates a superuser with the following credentials:
+  <div>
+    - Username: `admin`
+    - Password: `Password123!`
+  </div>
 
-A Django superuser also need creating by connecting to the Backend app and run the command:
+- **Custom superuser credentials**: If you wish to create a new super user with custom credentials, do the following:
+  <div>
+    - Add environment variables to the Backend app:
+      <div>
+        ```yaml
+        environment:
+          - SUPERUSER_DEFAULT_USERNAME : your_username
+          - SUPERUSER_DEFAULT_EMAIL : your_email
+          - SUPERUSER_DEFAULT_PASSWORD : your_password
+        ```
+      </div>
+    - Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
+  </div>
 
-```bash
-python manage.py createsuperuser
-```
+**The credentials will be applied after restarting the Backend app.**
 
-Some first instances of Carrot also need creating after the Backend app up and running. Doing this be access the URL: `<backend-URL>/admin/`, log in using the super user credentials, then create first `Data partner`, `Dataset`, and `Project`.
+---
 
+Now, **restart your app for the environment variables to be applied**.
+
+After that, Carrot will seed the app's database with the OMOP table and field names. 
+
+Some **First Instances of Carrot** also need creating after the Backend app up and running. 
+<div>
+  - Doing this be access the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
+
+  - Then create first instance of the `Data partner`, `Dataset`, and `Project`.
+</div>
 ### Frontend app
 
 Navigate to `Environment variables` section under `Settings` of your Frontend web app, then add the variables below:

--- a/website/src/pages/mapper/deployment/azure/steps.mdx
+++ b/website/src/pages/mapper/deployment/azure/steps.mdx
@@ -97,13 +97,14 @@ Select `Container Image` as the mode of deploying.
 **Tags**: Give name and value for the web app's tag, if needed.
 
 **Container Image**: A default image will be used as you create a function app. Therefore, after the app being deployed you must change this image by doing so:
-
-- Access the newly created Function app
-- Under tab `Deployment`, choose `Deployment center`
-- Choose `Private Registry` as Registry source
-- Change Server URL to: `https://ghcr.io`
-- Change Full Image Name and Tag to: `health-informatics-uon/carrot/workers:<tag>`. Look for available tags [here](https://github.com/Health-Informatics-UoN/carrot-mapper/pkgs/container/carrot%2Fworkers).
-- Save the setting
+  <div>
+    1. Access the newly created Function app.
+    2. Under tab `Deployment`, choose `Deployment center`.
+    3. Choose `Private Registry` as Registry source.
+    4. Change Server URL to: `https://ghcr.io`.
+    5. Change Full Image Name and Tag to: `health-informatics-uon/carrot/workers:<tag>`. Look for available tags [here](https://github.com/Health-Informatics-UoN/carrot-mapper/pkgs/container/carrot%2Fworkers).
+    6. Save the Settings.
+  </div>
 
 ### PostgreSQL Database
 
@@ -276,32 +277,36 @@ Navigate to `Environment variables` section under `Settings` of your Backend web
 
 - **Custom superuser credentials**: If you wish to create a new super user with custom credentials, do the following:
   <div>
-    - Add environment variables to the Backend app:
+    1. Add three more environment variables below to the Backend app's `Environment Variables`:
       <div>
-        ```yaml
-        environment:
+        ```
           - SUPERUSER_DEFAULT_USERNAME : your_username
           - SUPERUSER_DEFAULT_EMAIL : your_email
           - SUPERUSER_DEFAULT_PASSWORD : your_password
         ```
       </div>
-    - Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
+    2. Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
   </div>
 
 **The credentials will be applied after restarting the Backend app.**
 
 ---
 
-Now, **restart your app for the environment variables to be applied**.
+**Now, do the following steps:**
 
-After that, Carrot will seed the app's database with the OMOP table and field names. 
+1. **Restart your app for the environment variables to be applied**.
 
-Some **First Instances of Carrot** also need creating after the Backend app up and running. 
-<div>
-  - Doing this be access the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
+2. After that, Carrot will seed the app's database with the OMOP table and field names. 
 
-  - Then create first instance of the `Data partner`, `Dataset`, and `Project`.
-</div>
+3. Some **First Instances of Carrot** also need creating after the Backend app up and running. 
+
+    **Follow these steps to create the first instances:**
+    <div>
+      1. Doing this by access the URL: `<backend-URL>/admin/`, log in using the [superuser credentials](#superuserCredentialsAzure).
+
+      2. Then create first instance of the `Data partner`, `Dataset`, and `Project`.
+    </div>
+
 ### Frontend app
 
 Navigate to `Environment variables` section under `Settings` of your Frontend web app, then add the variables below:

--- a/website/src/pages/mapper/deployment/configuration.mdx
+++ b/website/src/pages/mapper/deployment/configuration.mdx
@@ -119,6 +119,13 @@ Carrot can be configured using environment variables which can be different depe
         is used in Production.
       </Td>
     </Tr>
+        <Tr>
+      <Td><Mandatory>`SUPERUSER_DEFAULT_USERNAME`</Mandatory> <Mandatory>`SUPERUSER_DEFAULT_PASSWORD`</Mandatory> `SUPERUSER_DEFAULT_EMAIL` </Td>
+      <Td>
+        Credentials required to create the first superuser in Carrot. Without these variables, no superuser will be created.
+        `SUPERUSER_DEFAULT_EMAIL` is defaulted to `user@carrot`.
+      </Td>
+    </Tr>
   </tbody>
 </Table>
 
@@ -155,6 +162,9 @@ api:
     - WORKERS_RULES_EXPORT_NAME=rules-exports-local
     - STORAGE_CONN_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;
     - SIGNING_KEY=secret
+    - SUPERUSER_DEFAULT_USERNAME=admin-local
+    - SUPERUSER_DEFAULT_PASSWORD=admin-password
+    - SUPERUSER_DEFAULT_EMAIL=admin@carrot
   volumes:
     - ./app/api:/api
   depends_on:
@@ -259,7 +269,24 @@ Below is just an example of variables that need adding to the Azure environment.
     "name": "WORKERS_URL",
     "value": "<workers-url>",
     "slotSetting": false
+  },
+  {
+    "name": "SUPERUSER_DEFAULT_USERNAME",
+    "value": "<admin-carrot>",
+    "slotSetting": false
+  },
+  {
+    "name": "SUPERUSER_DEFAULT_PASSWORD",
+    "value": "<admin-pass>",
+    "slotSetting": false
+  },
+  {
+    "name": "SUPERUSER_DEFAULT_EMAIL",
+    "value": "<admin@carrot>",
+    "slotSetting": false
   }
+
+
 ]
 ```
 

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -65,7 +65,7 @@ To do that, superuser credentials need adding as environment variables by doing 
 
 
 <Callout type="info">
-  Without the superuser credentials in the environment variables, no users will be created. However, you can still add a superuser later by doing it manually (using the command `python manage.py createsuperuser` on the `api` container) or automatically (using steps above, and then restarting the containers)
+  Without the superuser credentials in the environment variables, no users will be created. However, you can still add a superuser later by doing it manually (using the command `python manage.py createsuperuser` on the `api` container) or automatically (using steps above, and then restarting the containers).
 </Callout>
 
 ### Warm up

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -61,7 +61,7 @@ Before running the Docker Compose, decide whether to use **Default Superuser Cre
   <div>
     1. Locate the `docker-compose.yml` file in the `root` directory of Carrot.
     2. Open the file and find the `api` service.
-    3. Make changes in the `environment` section of the `api` service as follows:
+    3. Add the following variables to  the `environment` section of the `api` service as follows:
 
       ```yaml
       environment:
@@ -78,9 +78,6 @@ Before running the Docker Compose, decide whether to use **Default Superuser Cre
 </Callout>
 
 Once you change the environment variables, **your custom super user credentials will be replaced with the default super user credentials**.
-  <div>
-    - Now you can use your **superuser credentials** to **log in to the Django Admin panel** (steps are mentioned later in this guide).
-  </div>
 
 ### Warm up
 

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -45,37 +45,27 @@ To set this up, at the `app/workers` directory, add a folder named `Secrets`. In
 ```
 
 ### Superuser Credentials setup
+A superuser needs to be created to access the Django admin dashboard and Carrot frontend.
 
-Before running the Docker Compose, decide whether to use **Default Superuser Credentials** or **Custom Superuser Credentials** for logging into the Django Admin Panel.
+To do that, superuser credentials need adding as environment variables by doing the following steps:
 
-<div id="superuserCredentials">
-  - <u>**Default Super User Creation**</u>: By default, **Carrot creates a superuser** with the following credentials:
-    <div>
-    - **Username**: `admin`
-    - **Password**: `Password123!`
-    - **Email**: `user@carrot`
-    </div>
-  **Note:** If you wish to use these **default credentials**, you can skip the steps below.
-</div>
-
-- <u>**Custom Superuser Credentials**</u>: If you **wish to create a new super user with custom credentials**, do the following:
-  <div>
-    1. Locate the `docker-compose.yml` file in the `root` directory of Carrot.
-    2. Add the following variables to  the `environment` section of the `api` service as follows:
+    - Locate the `docker-compose.yml` file in the `root` directory of Carrot.
+    - Add the following variables to  the `environment` section of the `api` service:
 
       ```yaml
       environment:
-        - SUPERUSER_DEFAULT_USERNAME=<your_username>
-        - SUPERUSER_DEFAULT_EMAIL=<your_email>
-        - SUPERUSER_DEFAULT_PASSWORD=<your_password>
+        - SUPERUSER_DEFAULT_USERNAME=<superuser_username>
+        - SUPERUSER_DEFAULT_PASSWORD=<superuser_password>
+        - SUPERUSER_DEFAULT_EMAIL=<superuser_email> // Defaulted to `user@carrot`
         - ...other variables
       ```
 
-    3. Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
-  </div>
+    - Replace `superuser_username`, `superuser_email`, and `superuser_password` with your desired credentials.
+    - After the [Warm up](#warm-up) step is done, a superuser will be created automatically with the credentials you chose above.
 
-<Callout type="warning">
-  **Custom superuser credentials must be set before running Docker Compose for the first time**. If not, the **default superuser credentials will be applied**.
+
+<Callout type="info">
+  Without the superuser credentials in the environment variables, no users will be created. However, you can still add a superuser later by doing it manually (using the command `python manage.py createsuperuser` on the `api` container) or automatically (using steps above, and then restarting the containers)
 </Callout>
 
 ### Warm up
@@ -110,7 +100,7 @@ Docker will mount the `app/api` and `app/next-client-app` directories to its env
 
 Create some first instances in Carrot app by logging to Django Admin panel `http://localhost:8000/admin/`.
 
-1. You can **log in to the Admin Panel** using the [superuser credentials](#superuserCredentials), either the **default credentials** or the **custom credentials** you configured earlier.
+1. You can **log in to the Admin Panel** using the [superuser credentials](#superuser-credentials-setup) you configured earlier.
 2. Once logged in, you will be presented with the Django Admin panel.
 3. Following this order, fill out the required information to create new instance of `Data Partner`, `Dataset` and `Project`.
 

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -59,18 +59,18 @@ Before running the Docker Compose, decide whether to use **Default Superuser Cre
 
 - <u>**Custom Superuser Credentials**</u>: If you **wish to create a new super user with custom credentials**, do the following:
   <div>
-  - Locate the `docker-compose.yml` file in the `root` directory of Carrot.
-  - Open the file and find the `api` service.
-  - Make changes in the `environment` section of the `api` service as follows:
+    1. Locate the `docker-compose.yml` file in the `root` directory of Carrot.
+    2. Open the file and find the `api` service.
+    3. Make changes in the `environment` section of the `api` service as follows:
 
-    ```yaml
-    environment:
-      - SUPERUSER_DEFAULT_USERNAME : your_username
-      - SUPERUSER_DEFAULT_EMAIL : your_email
-      - SUPERUSER_DEFAULT_PASSWORD : your_password
-    ```
+      ```yaml
+      environment:
+        - SUPERUSER_DEFAULT_USERNAME : your_username
+        - SUPERUSER_DEFAULT_EMAIL : your_email
+        - SUPERUSER_DEFAULT_PASSWORD : your_password
+      ```
 
-  - Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
+    4. Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
   </div>
 
 <Callout type="warning">
@@ -125,9 +125,9 @@ Since we already have the **Superuser credentials set up**, we can now proceed t
 
 Create some first instances in Carrot app by logging to Django Admin panel `http://localhost:8000/admin/`.
 
-- You can **logging the Admin Panel** using the [superuser credentials](#superuserCredentials), either the **default credentials** or the **custom credentials** you configured earlier.
-- Once logged in, you will be presented with the Django Admin panel.
-- Following this order, fill out the required information to create new instance of `Data Partner`, `Dataset` and `Project`.
+1. You can **logging the Admin Panel** using the [superuser credentials](#superuserCredentials), either the **default credentials** or the **custom credentials** you configured earlier.
+2. Once logged in, you will be presented with the Django Admin panel.
+3. Following this order, fill out the required information to create new instance of `Data Partner`, `Dataset` and `Project`.
 
 ### Azure local storage setup
 

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -44,6 +44,44 @@ To set this up, at the `app/workers` directory, add a folder named `Secrets`. In
 }
 ```
 
+### Environment variables setup for Super User Credentials.
+
+Before running the Docker Compose, decide whether to use **Default Superuser Credentials** or **Custom Superuser Credentials** for logging into the Django Admin Panel.
+
+<div id="superuserCredentials">
+  - <u>**Default Super User Creation**</u>: By default, **Carrot creates a superuser** with the following credentials:
+    <div>
+    - **Username**: `admin` 
+    - **Password**: `Password123!`
+    </div>
+  **Note:** If you wish to use these **default credentials**, you can **skip the setup** for **<u>custom super user credentials</u>**.
+</div>
+
+- <u>**Custom Superuser Credentials**</u>: If you **wish to create a new super user with custom credentials**, do the following:
+  <div>
+  - Locate the `docker-compose.yml` file in the `root` directory of Carrot.
+  - Open the file and find the `api` service.
+  - Make changes in the `environment` section of the `api` service as follows:
+
+    ```yaml
+    environment:
+      - SUPERUSER_DEFAULT_USERNAME : your_username
+      - SUPERUSER_DEFAULT_EMAIL : your_email
+      - SUPERUSER_DEFAULT_PASSWORD : your_password
+    ```
+
+  - Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
+  </div>
+
+<Callout type="warning">
+  **Custom superuser credentials must be set before running Docker-Compose**. If not, the **default credentials created by the Carrot will be applied**.
+</Callout>
+
+Once you change the environment variables, **your custom super user credentials will be replaced with the default super user credentials**.
+  <div>
+    - Now you can use your **superuser credentials** to **log in to the Django Admin panel** (steps are mentioned later in this guide).
+  </div>
+
 ### Warm up
 
 At the `root` directory, run to command below to start the application stack using Docker compose.
@@ -52,9 +90,13 @@ At the `root` directory, run to command below to start the application stack usi
 docker compose up -d
 ```
 
-This runs the database (`db`), Azurite emulator (`Azurite`), Azure functions (`workers`) and will build Carrot's backend (`api`) and frontend (`frontend`). This process will be on the background and take some time, but you can always check it through Docker Desktop app. When all of containers, except `omop-lite`, are up and running successfully, Carrot's frontend and backend can be accessed through `http://localhost:3000/` and `http://localhost:8000/admin/` respectively. **However**, please complete the remaining steps, while containers are running, to make sure Carrot running correctly.
+This runs the database (`db`), Azurite emulator (`Azurite`), Azure functions (`workers`) and will build Carrot's backend (`api`) and frontend (`frontend`). This process will be on the background and take some time, but you can always check it through Docker Desktop app.
 
-More details about Docker compose's configuration can be found [here](configuration)
+When all of containers, except `omop-lite`, are up and running successfully, Carrot's frontend and backend can be accessed through `http://localhost:3000/` and `http://localhost:8000/admin/` respectively.
+
+- **However**, please complete the remaining steps, while containers are running, to make sure Carrot is running correctly.
+
+More details about Docker compose's configuration can be found [here](configuration).
 
 <Callout type="info">
 
@@ -70,45 +112,22 @@ Docker will mount the `app/api` and `app/next-client-app` directories to its env
 
 ### Initial data preparation
 
-You need to seed the Carrot app database with the OMOP table and field names.
+When running the Docker Compose for the first time, wait until the `omop-lite` container shuts down. **The execution time may vary depending of the size of the Vocabs folder**.
 
-This can be done by either using your terminal and access the `api` container on Docker or using Docker Desktop.
+**Following the containers are up and running, Carrot will proceed to the next steps.**
+  <div>
+  - **Automatic Data Seeding**: The system will automatically populate the required database tables and data when the application starts.
+  </div>
 
-<Tabs items={['Using Terminal', 'Using Docker Desktop']}>
-  <Tabs.Tab>
-  At the `root` directory, open terminal and run
-
-```bash
-docker exec -it carrot-mapper-dev-api-1 bash
-```
-
-Then run
-
-```bash
-python manage.py loaddata mapping filetypes
-```
-
-  </Tabs.Tab>
-  <Tabs.Tab>
-
-Navigate to your Docker Desktop, under `carrot-mapper-dev`, choose `api` container, choose `Exec` tab, then run:
-
-```bash
-python manage.py loaddata mapping filetypes
-```
-
-  </Tabs.Tab>
-</Tabs>
-
-After that, add a new admin user (Django superuser) by running:
-
-```bash
-python manage.py createsuperuser
-```
+Since we already have the **Superuser credentials set up**, we can now proceed to the next steps.
 
 ### First instances creation
 
-Create some first instances in Carrot app by logging to Django Admin panel `http://localhost:8000/admin/` (using the credentials in the last step). Following this order, fill out the required information to create new `Data Partner`, `Dataset` and `Project`.
+Create some first instances in Carrot app by logging to Django Admin panel `http://localhost:8000/admin/`.
+
+- You can **logging the Admin Panel** using the [superuser credentials](#superuserCredentials), either the **default credentials** or the **custom credentials** you configured earlier.
+- Once logged in, you will be presented with the Django Admin panel.
+- Following this order, fill out the required information to create new instance of `Data Partner`, `Dataset` and `Project`.
 
 ### Azure local storage setup
 

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -44,40 +44,39 @@ To set this up, at the `app/workers` directory, add a folder named `Secrets`. In
 }
 ```
 
-### Environment variables setup for Super User Credentials.
+### Superuser Credentials setup
 
 Before running the Docker Compose, decide whether to use **Default Superuser Credentials** or **Custom Superuser Credentials** for logging into the Django Admin Panel.
 
 <div id="superuserCredentials">
   - <u>**Default Super User Creation**</u>: By default, **Carrot creates a superuser** with the following credentials:
     <div>
-    - **Username**: `admin` 
+    - **Username**: `admin`
     - **Password**: `Password123!`
+    - **Email**: `user@carrot`
     </div>
-  **Note:** If you wish to use these **default credentials**, you can **skip the setup** for **<u>custom super user credentials</u>**.
+  **Note:** If you wish to use these **default credentials**, you can skip the steps below.
 </div>
 
 - <u>**Custom Superuser Credentials**</u>: If you **wish to create a new super user with custom credentials**, do the following:
   <div>
     1. Locate the `docker-compose.yml` file in the `root` directory of Carrot.
-    2. Open the file and find the `api` service.
-    3. Add the following variables to  the `environment` section of the `api` service as follows:
+    2. Add the following variables to  the `environment` section of the `api` service as follows:
 
       ```yaml
       environment:
-        - SUPERUSER_DEFAULT_USERNAME : your_username
-        - SUPERUSER_DEFAULT_EMAIL : your_email
-        - SUPERUSER_DEFAULT_PASSWORD : your_password
+        - SUPERUSER_DEFAULT_USERNAME=<your_username>
+        - SUPERUSER_DEFAULT_EMAIL=<your_email>
+        - SUPERUSER_DEFAULT_PASSWORD=<your_password>
+        - ...other variables
       ```
 
-    4. Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
+    3. Replace `your_username`, `your_email`, and `your_password` with your desired credentials.
   </div>
 
 <Callout type="warning">
-  **Custom superuser credentials must be set before running Docker-Compose**. If not, the **default credentials created by the Carrot will be applied**.
+  **Custom superuser credentials must be set before running Docker Compose for the first time**. If not, the **default superuser credentials will be applied**.
 </Callout>
-
-Once you change the environment variables, **your custom super user credentials will be replaced with the default super user credentials**.
 
 ### Warm up
 
@@ -91,13 +90,13 @@ This runs the database (`db`), Azurite emulator (`Azurite`), Azure functions (`w
 
 When all of containers, except `omop-lite`, are up and running successfully, Carrot's frontend and backend can be accessed through `http://localhost:3000/` and `http://localhost:8000/admin/` respectively.
 
-- **However**, please complete the remaining steps, while containers are running, to make sure Carrot is running correctly.
+**However**, please complete the remaining steps, while containers are running, to make sure Carrot is running correctly.
 
 More details about Docker compose's configuration can be found [here](configuration).
 
 <Callout type="info">
 
-The `omop-lite` container, whose task is creating `omop` schema on `db` and install vocabularies there, will be shut down automatically after successfully done its jobs.
+The `omop-lite` container, whose task is creating `omop` schema on `db` and install vocabularies there, will be shut down automatically after successfully done its jobs. The execution time for `omop-lite` may vary depending of the size of the Vocabs folder.
 
 </Callout>
 
@@ -106,17 +105,6 @@ The `omop-lite` container, whose task is creating `omop` schema on `db` and inst
 Docker will mount the `app/api` and `app/next-client-app` directories to its environment, so any changes in the code of the backend or frontend will be reflected in the running application.
 
 </Callout>
-
-### Initial data preparation
-
-When running the Docker Compose for the first time, wait until the `omop-lite` container shuts down. **The execution time may vary depending of the size of the Vocabs folder**.
-
-**Following the containers are up and running, Carrot will proceed to the next steps.**
-  <div>
-  - **Automatic Data Seeding**: The system will automatically populate the required database tables and data when the application starts.
-  </div>
-
-Since we already have the **Superuser credentials set up**, we can now proceed to the next steps.
 
 ### First instances creation
 

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -110,7 +110,7 @@ Docker will mount the `app/api` and `app/next-client-app` directories to its env
 
 Create some first instances in Carrot app by logging to Django Admin panel `http://localhost:8000/admin/`.
 
-1. You can **logging the Admin Panel** using the [superuser credentials](#superuserCredentials), either the **default credentials** or the **custom credentials** you configured earlier.
+1. You can **log in to the Admin Panel** using the [superuser credentials](#superuserCredentials), either the **default credentials** or the **custom credentials** you configured earlier.
 2. Once logged in, you will be presented with the Django Admin panel.
 3. Following this order, fill out the required information to create new instance of `Data Partner`, `Dataset` and `Project`.
 


### PR DESCRIPTION
<h1> Carrot mapper documentation refactor </h1>

This Pull Request  #19 refactors the Carrot Mapper Quick Start Guide and the Carrot Mapper → Deployment on Azure: Step-by-Step Guide documentation.

<h4>Key Updates</h4>

- Added instructions for Automatic Seeding Data and Super User Creation.

**To view the website, do the following:**

- Clone the Carrot Github Repository

- Locate the file to the following: `root directory of the repo` **->** `cd website`

- Inside the directory, run the following command:

```
npm run dev
```

- After running the command, use the following URL for reading the documentation website:

- https://carrot.ac.uk/mapper/dev_guide/quickstart#initial-data-preparation

- https://carrot.ac.uk/mapper/deployment/azure/steps#resources-creation

--- 
Looking forward to your feedback on further refinements!

Let me know if you need any more tweaks!

closes #19