### PR TITLE
updates the docs for input dir

### DIFF
--- a/website/src/pages/transform/quickstart.mdx
+++ b/website/src/pages/transform/quickstart.mdx
@@ -32,7 +32,7 @@ Enter the following (as one command):
 To process a test dataset included in the repository, run:
 ```bash
 carrot-transform run mapstream \
-  carrottransform/examples/test/inputs \
+  --input-dir carrottransform/examples/test/inputs \
   --rules-file carrottransform/examples/test/rules/rules_14June2021.json \
   --person-file carrottransform/examples/test/inputs/Demographics.csv \
   --output-dir carrottransform/examples/test/test_output \


### PR DESCRIPTION
updates the documentation to handle the fact that the --input-dir parameter now comes in as a --input-dir argument https://github.com/Health-Informatics-UoN/carrot-transform/issues/8

| <!-- # Delete content types that don't apply to your pull request -->|
|-|
📝 Documentation

## PR Description

simple change to the quickstart documentation

## Related Issues or other material
Related # https://github.com/Health-Informatics-UoN/carrot-transform/issues/8
Closes # https://github.com/Health-Informatics-UoN/carrot-transform/issues/8

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [] This PR contains doesn't need to per the below explanation
