### PR TITLE
Updated Queue Names

### DIFF
--- a/website/src/pages/mapper/deployment/configuration.mdx
+++ b/website/src/pages/mapper/deployment/configuration.mdx
@@ -154,12 +154,12 @@ api:
     - DB_USER=postgres
     - DB_PASSWORD=postgres
     - DEBUG=True
-    - WORKERS_UPLOAD_NAME=uploadreports-local
+    - WORKERS_UPLOAD_NAME=upload-reports-queue
     - SECRET_KEY=secret
     - WORKERS_URL=http://workers:80
     - WORKERS_RULES_NAME=RulesOrchestrator
     - WORKERS_RULES_KEY=rules_key
-    - WORKERS_RULES_EXPORT_NAME=rules-exports-local
+    - WORKERS_RULES_EXPORT_NAME=rules-exports-queue
     - STORAGE_CONN_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;
     - SIGNING_KEY=secret
     - SUPERUSER_DEFAULT_USERNAME=admin-local
@@ -554,9 +554,9 @@ workers:
     - FUNCTIONS_WORKER_RUNTIME=python
     - STORAGE_CONN_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;
     - APP_URL=http://api:8000/
-    - WORKERS_UPLOAD_NAME=uploadreports-local
-    - RULES_QUEUE_NAME=rules-local
-    - RULES_FILE_QUEUE_NAME=rules-exports-local
+    - WORKERS_UPLOAD_NAME=upload-reports-queue
+    - RULES_QUEUE_NAME=rules-queue
+    - RULES_FILE_QUEUE_NAME=rules-exports-queue
     - WEBSITE_HOSTNAME=localhost:7071
     - DB_ENGINE=django.db.backends.postgresql
     - DB_HOST=db
@@ -684,9 +684,9 @@ This storage requires pre-made `Queues` and `Blob Containers` with purposes belo
   <Tabs.Tab>
 
 ```
-Queue for Rules actions triggers, e.g., `rules`
-Queue for Mapping rules exports, e.g., `rules-exports`
-Queue for Scan reports uploads, e.g., `uploadreports`
+Queue for Rules actions triggers, e.g., `rules-queue`
+Queue for Mapping rules exports, e.g., `rules-exports-queue`
+Queue for Scan reports uploads, e.g., `upload-reports-queue`
 ```
 
 Note: Queues names should match with `RULES_QUEUE_NAME` `RULES_FILE_QUEUE_NAME` `WORKERS_UPLOAD_NAME` in `Azure functions`.

--- a/website/src/pages/mapper/dev_guide/quickstart.mdx
+++ b/website/src/pages/mapper/dev_guide/quickstart.mdx
@@ -114,9 +114,9 @@ To do this, with the `workers` container in Docker Desktop is running, open `MS 
   <Tabs.Tab>
 
 ```
-rules-local
-rules-exports-local
-uploadreports-local
+rules-queue
+rules-exports-queue
+upload-reports-queue
 ```
 
   </Tabs.Tab>


### PR DESCRIPTION
♻️ Refactor - #25

## PR Description

This PR updates the Carrot Docs website to reflect the upcoming changes to the Queue naming conventions in Carrot-Mapper, specifically the removal of "local" from Queue names and updating all references to the new naming convention.

Closes  #25

