### PR TITLE
Add K8s manifest for Carrot Mapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ jspm_packages
 .env
 .DS_Store
 website/out/
+vocabs

--- a/samples/Carrot-Mapper/k8s/airflow/configmap.yaml
+++ b/samples/Carrot-Mapper/k8s/airflow/configmap.yaml
@@ -1,0 +1,34 @@
+# ConfigMap for shared configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: airflow-config
+  namespace: carrot-mapper
+data:
+  AIRFLOW__CORE__EXECUTOR: "LocalExecutor"
+  AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+  AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "False"
+  AIRFLOW__WEBSERVER__WEB_SERVER_PORT: "8080"
+  STORAGE_TYPE: "minio"
+  AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.basic_auth"
+  AIRFLOW_VAR_MINIO_ENDPOINT: "http://minio-service:9000"
+  AIRFLOW_VAR_MINIO_ACCESS_KEY: "minioadmin"
+  AIRFLOW__DATABASE__SQL_ALCHEMY_SCHEMA: "airflow"
+  AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER: "s3://airflow-logs"
+  AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID: "minio_conn"
+  AIRFLOW__LOGGING__REMOTE_LOGGING: "True"
+
+---
+# Secret for sensitive data
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-secrets
+  namespace: carrot-mapper
+type: Opaque
+stringData:
+  AIRFLOW_ADMIN_PASSWORD: "admin"
+  AIRFLOW_VAR_MINIO_SECRET_KEY: "minioadmin"
+  AIRFLOW__WEBSERVER__SECRET_KEY: "secret"
+  AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://postgres:postgres@postgres-service:5432/postgres?options=-csearch_path%3Dairflow"
+  AIRFLOW_CONN_POSTGRES_DB_CONN: "postgresql+psycopg2://postgres:postgres@postgres-service:5432/postgres"

--- a/samples/Carrot-Mapper/k8s/airflow/scheduler-deployment.yaml
+++ b/samples/Carrot-Mapper/k8s/airflow/scheduler-deployment.yaml
@@ -1,0 +1,71 @@
+# Airflow Scheduler Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-scheduler
+  namespace: carrot-mapper
+  labels:
+    app: airflow-scheduler
+    component: airflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: airflow-scheduler
+  template:
+    metadata:
+      labels:
+        app: airflow-scheduler
+        component: airflow
+    spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:14
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U postgres; do
+                echo "Waiting for postgres..."
+                sleep 2
+              done
+        - name: wait-for-minio
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -f http://minio-service:9000/minio/health/live; do
+                echo "Waiting for minio..."
+                sleep 2
+              done
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -f http://api-service:8000/health; do
+                echo "Waiting for API..."
+                sleep 5
+              done
+      containers:
+        - name: airflow-scheduler
+          image: ghcr.io/health-informatics-uon/carrot/airflow-scheduler:3.1.0
+          env:
+            - name: AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER
+              value: "True"
+            - name: AIRFLOW_DEBUG_MODE
+              value: "True"
+          envFrom:
+            - configMapRef:
+                name: airflow-config
+            - secretRef:
+                name: airflow-secrets
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"

--- a/samples/Carrot-Mapper/k8s/airflow/service.yaml
+++ b/samples/Carrot-Mapper/k8s/airflow/service.yaml
@@ -1,0 +1,17 @@
+# Airflow Webserver Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: airflow-webserver-service
+  namespace: carrot-mapper
+  labels:
+    app: airflow-webserver
+    component: airflow
+spec:
+  selector:
+    app: airflow-webserver
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: http
+  type: LoadBalancer

--- a/samples/Carrot-Mapper/k8s/airflow/webserver-deployment.yaml
+++ b/samples/Carrot-Mapper/k8s/airflow/webserver-deployment.yaml
@@ -1,0 +1,89 @@
+# Airflow Scheduler Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: airflow-webserver
+  namespace: carrot-mapper
+  labels:
+    app: airflow-webserver
+    component: airflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: airflow-webserver
+  template:
+    metadata:
+      labels:
+        app: airflow-webserver
+        component: airflow
+    spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:14
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U postgres; do
+                echo "Waiting for postgres..."
+                sleep 2
+              done
+        - name: wait-for-minio
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -f http://minio-service:9000/minio/health/live; do
+                echo "Waiting for minio..."
+                sleep 2
+              done
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -f http://api-service:8000/health; do
+                echo "Waiting for API..."
+                sleep 5
+              done
+      containers:
+        - name: airflow-webserver
+          image: ghcr.io/health-informatics-uon/carrot/airflow-webserver:3.1.0
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: AIRFLOW_ADMIN_USERNAME
+              value: "admin"
+            - name: AIRFLOW_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-secrets
+                  key: AIRFLOW_ADMIN_PASSWORD
+          envFrom:
+            - configMapRef:
+                name: airflow-config
+            - secretRef:
+                name: airflow-secrets
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10

--- a/samples/Carrot-Mapper/k8s/api/configmap.yaml
+++ b/samples/Carrot-Mapper/k8s/api/configmap.yaml
@@ -1,0 +1,41 @@
+# ConfigMap for api configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-config
+  namespace: carrot-mapper
+data:
+  DB_ENGINE: "django.db.backends.postgresql"
+  DB_HOST: "postgres-service"
+  DB_PORT: "5432"
+  DB_NAME: "postgres"
+  DB_USER: "postgres"
+  STORAGE_TYPE: "minio"
+  MINIO_ENDPOINT: "minio-service:9000"
+  MINIO_ACCESS_KEY: "minioadmin"
+  FRONTEND_URL: "http://frontend-service:3000"
+  DEBUG: "True"
+  WORKER_SERVICE_TYPE: "airflow"
+  AIRFLOW_BASE_URL: "http://airflow-webserver-service:8080/api/v1/"
+  AIRFLOW_AUTO_MAPPING_DAG_ID: "auto_mapping"
+  AIRFLOW_SCAN_REPORT_PROCESSING_DAG_ID: "scan_report_processing"
+  AIRFLOW_RULES_EXPORT_DAG_ID: "rules_export"
+  AIRFLOW_ADMIN_USERNAME: "admin"
+  DATA_UPLOAD_MAX_MEMORY_SIZE: "10485760"
+  SUPERUSER_DEFAULT_EMAIL: "admin@carrot.com"
+  SUPERUSER_DEFAULT_USERNAME: "admin"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-secrets
+  namespace: carrot-mapper
+type: Opaque
+stringData:
+  DB_PASSWORD: "postgres"
+  SECRET_KEY: "secret"
+  SIGNING_KEY: "secret"
+  MINIO_SECRET_KEY: "minioadmin"
+  AIRFLOW_ADMIN_PASSWORD: "admin"
+  SUPERUSER_DEFAULT_PASSWORD: "admin"

--- a/samples/Carrot-Mapper/k8s/api/deployment.yaml
+++ b/samples/Carrot-Mapper/k8s/api/deployment.yaml
@@ -1,0 +1,80 @@
+# API Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: carrot-mapper
+  labels:
+    app: api
+    component: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+        component: backend
+    spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:14
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U postgres; do
+                echo "Waiting for postgres..."
+                sleep 2
+              done
+        - name: wait-for-minio
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -f http://minio-service:9000/minio/health/live; do
+                echo "Waiting for minio..."
+                sleep 2
+              done
+      containers:
+        - name: api
+          image: ghcr.io/health-informatics-uon/carrot/backend:3.1.0
+          ports:
+            - containerPort: 8000
+              name: api
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: ALLOWED_HOSTS
+              value: '["localhost","127.0.0.1","api-service","$(POD_IP)"]'
+          envFrom:
+            - configMapRef:
+                name: api-config
+            - secretRef:
+                name: api-secrets
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/samples/Carrot-Mapper/k8s/api/service.yaml
+++ b/samples/Carrot-Mapper/k8s/api/service.yaml
@@ -1,0 +1,42 @@
+# API Service - For other pods to interact with the API
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  namespace: carrot-mapper
+  labels:
+    app: api
+    component: backend
+    service-type: api
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: api
+  selector:
+    app: api
+    component: backend
+
+---
+# Django Admin Console Service - For admin access
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-admin-service
+  namespace: carrot-mapper
+  labels:
+    app: api
+    component: backend
+    service-type: admin
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+      name: console
+  selector:
+    app: api
+    component: backend

--- a/samples/Carrot-Mapper/k8s/api/service.yaml
+++ b/samples/Carrot-Mapper/k8s/api/service.yaml
@@ -1,4 +1,4 @@
-# API Service - For other pods to interact with the API
+# API Service
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,34 +9,11 @@ metadata:
     component: backend
     service-type: api
 spec:
-  type: ClusterIP
-  ports:
-    - port: 8000
-      targetPort: 8000
-      protocol: TCP
-      name: api
-  selector:
-    app: api
-    component: backend
-
----
-# Django Admin Console Service - For admin access
-apiVersion: v1
-kind: Service
-metadata:
-  name: api-admin-service
-  namespace: carrot-mapper
-  labels:
-    app: api
-    component: backend
-    service-type: admin
-spec:
   type: LoadBalancer
   ports:
     - port: 8000
       targetPort: 8000
-      protocol: TCP
-      name: console
+      name: api
   selector:
     app: api
     component: backend

--- a/samples/Carrot-Mapper/k8s/db/configmap.yaml
+++ b/samples/Carrot-Mapper/k8s/db/configmap.yaml
@@ -1,0 +1,20 @@
+# ConfigMap for db configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-config
+  namespace: carrot-mapper
+data:
+  POSTGRES_DB: "postgres"
+  POSTGRES_USER: "postgres"
+
+---
+# Secret for sensitive data
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secrets
+  namespace: carrot-mapper
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: "postgres"

--- a/samples/Carrot-Mapper/k8s/db/deployment.yaml
+++ b/samples/Carrot-Mapper/k8s/db/deployment.yaml
@@ -1,0 +1,61 @@
+# PostgreSQL Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: carrot-mapper
+  labels:
+    app: postgres
+    component: database
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        component: database
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:14
+          ports:
+            - containerPort: 5432
+              name: postgres
+          envFrom:
+            - configMapRef:
+                name: db-config
+            - secretRef:
+                name: db-secrets
+          volumeMounts:
+            - name: postgres-storage
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: postgres-storage
+          persistentVolumeClaim:
+            claimName: postgres-pvc

--- a/samples/Carrot-Mapper/k8s/db/pvc.yaml
+++ b/samples/Carrot-Mapper/k8s/db/pvc.yaml
@@ -1,0 +1,12 @@
+# PersistentVolumeClaim for PostgreSQL
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: carrot-mapper
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/samples/Carrot-Mapper/k8s/db/service.yaml
+++ b/samples/Carrot-Mapper/k8s/db/service.yaml
@@ -1,0 +1,17 @@
+# PostgreSQL Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  namespace: carrot-mapper
+  labels:
+    app: postgres
+    component: database
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+  clusterIP: None
+  selector:
+    app: postgres

--- a/samples/Carrot-Mapper/k8s/frontend/configmap.yaml
+++ b/samples/Carrot-Mapper/k8s/frontend/configmap.yaml
@@ -1,0 +1,25 @@
+# ConfigMap for frontend configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+  namespace: carrot-mapper
+data:
+  BACKEND_URL: "http://api-service:8000"
+  BACKEND_ORIGIN: "api-service:8000"
+  NEXTAUTH_URL: "http://localhost:3000/"
+  NEXTAUTH_BACKEND_URL: "http://api-service:8000/api/"
+  NODE_ENV: "development"
+  BODY_SIZE_LIMIT: "20971520"
+  NEXT_PUBLIC_ENABLE_REUSE_TRIGGER_OPTION: "true"
+
+---
+# Secret for sensitive data
+apiVersion: v1
+kind: Secret
+metadata:
+  name: frontend-secrets
+  namespace: carrot-mapper
+type: Opaque
+stringData:
+  NEXTAUTH_SECRET: "verycomplexsecretkey"

--- a/samples/Carrot-Mapper/k8s/frontend/deployment.yaml
+++ b/samples/Carrot-Mapper/k8s/frontend/deployment.yaml
@@ -1,0 +1,72 @@
+# Frontend Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: carrot-mapper
+  labels:
+    app: frontend
+    component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+        component: frontend
+    spec:
+      initContainers:
+        - name: wait-for-api
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -f http://api-service:8000/health; do
+                echo "Waiting for API..."
+                sleep 5
+              done
+        - name: wait-for-airflow
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -f http://airflow-webserver-service:8080/health; do
+                echo "Waiting for Airflow..."
+                sleep 5
+              done
+      containers:
+        - name: frontend
+          image: ghcr.io/health-informatics-uon/carrot/frontend:3.1.0
+          command: ["node", "server.js"]
+          ports:
+            - containerPort: 3000
+              name: http
+          envFrom:
+            - configMapRef:
+                name: frontend-config
+            - secretRef:
+                name: frontend-secrets
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/samples/Carrot-Mapper/k8s/frontend/service.yaml
+++ b/samples/Carrot-Mapper/k8s/frontend/service.yaml
@@ -1,0 +1,17 @@
+# Frontend Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+  namespace: carrot-mapper
+  labels:
+    app: frontend
+    component: frontend
+spec:
+  selector:
+    app: frontend
+  ports:
+    - port: 3000
+      targetPort: 3000
+      name: http
+  type: LoadBalancer

--- a/samples/Carrot-Mapper/k8s/minio/configmap.yaml
+++ b/samples/Carrot-Mapper/k8s/minio/configmap.yaml
@@ -1,0 +1,21 @@
+# ConfigMap for minio configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minio-config
+  namespace: carrot-mapper
+data:
+  MINIO_ROOT_USER: "minioadmin"
+  MINIO_BROWSER: "on"
+  MINIO_DOMAIN: "minio.carrot-mapper.svc.cluster.local"
+
+---
+# Secret for sensitive data
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-secrets
+  namespace: carrot-mapper
+type: Opaque
+stringData:
+  MINIO_ROOT_PASSWORD: "minioadmin"

--- a/samples/Carrot-Mapper/k8s/minio/deployment.yaml
+++ b/samples/Carrot-Mapper/k8s/minio/deployment.yaml
@@ -1,0 +1,65 @@
+# MinIO Deployment
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: minio
+  namespace: carrot-mapper
+  labels:
+    app: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      annotations:
+        pod.alpha.kubernetes.io/initialized: "true"
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+          envFrom:
+            - configMapRef:
+                name: minio-config
+            - secretRef:
+                name: minio-secrets
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-pvc

--- a/samples/Carrot-Mapper/k8s/minio/pvc.yaml
+++ b/samples/Carrot-Mapper/k8s/minio/pvc.yaml
@@ -1,0 +1,13 @@
+# PersistentVolumeClaim for MinIO
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pvc
+  namespace: carrot-mapper
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: standard

--- a/samples/Carrot-Mapper/k8s/minio/service.yaml
+++ b/samples/Carrot-Mapper/k8s/minio/service.yaml
@@ -1,29 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: minio-console
-  namespace: carrot-mapper
-spec:
-  type: LoadBalancer
-  ports:
-    - port: 9001
-      targetPort: 9001
-      name: console
-  selector:
-    app: minio
-
----
-apiVersion: v1
-kind: Service
-metadata:
   name: minio-service
   namespace: carrot-mapper
 spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-    - port: 9000
-      targetPort: 9000
-      name: api
   selector:
     app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+  type: ClusterIP

--- a/samples/Carrot-Mapper/k8s/minio/service.yaml
+++ b/samples/Carrot-Mapper/k8s/minio/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-console
+  namespace: carrot-mapper
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 9001
+      targetPort: 9001
+      name: console
+  selector:
+    app: minio
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+  namespace: carrot-mapper
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 9000
+      targetPort: 9000
+      name: api
+  selector:
+    app: minio

--- a/samples/Carrot-Mapper/k8s/omop-lite/configmap.yaml
+++ b/samples/Carrot-Mapper/k8s/omop-lite/configmap.yaml
@@ -1,0 +1,10 @@
+# ConfigMap for shared configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: omop-lite-config
+  namespace: carrot-mapper
+data:
+  SCHEMA_NAME: "omop"
+  DATA_DIR: "vocabs"
+  SYNTHETIC: "true"

--- a/samples/Carrot-Mapper/k8s/omop-lite/deployment.yaml
+++ b/samples/Carrot-Mapper/k8s/omop-lite/deployment.yaml
@@ -1,0 +1,57 @@
+# OMOP Lite Job (runs once to completion)
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: omop-lite-init
+  namespace: carrot-mapper
+  labels:
+    app: omop-lite
+    component: initialization
+spec:
+  template:
+    metadata:
+      labels:
+        app: omop-lite
+        component: initialization
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:14
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-service -p 5432 -U postgres; do
+                echo "Waiting for postgres..."
+                sleep 2
+              done
+      containers:
+        - name: omop-lite
+          image: ghcr.io/health-informatics-uon/omop-lite
+          env:
+            - name: DB_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: api-config
+                  key: DB_HOST
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: api-secrets
+                  key: DB_PASSWORD
+            - name: DB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: api-config
+                  key: DB_NAME
+          envFrom:
+            - configMapRef:
+                name: omop-lite-config
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "2Gi"
+              cpu: "1000m"

--- a/samples/Carrot-Mapper/k8s/omop-lite/pvc.yaml
+++ b/samples/Carrot-Mapper/k8s/omop-lite/pvc.yaml
@@ -1,0 +1,12 @@
+# # PersistentVolumeClaim for OMOP vocabs
+# apiVersion: v1
+# kind: PersistentVolumeClaim
+# metadata:
+#   name: omop-vocabs-pvc
+#   namespace: carrot-mapper
+# spec:
+#   accessModes:
+#     - ReadWriteOnce
+#   resources:
+#     requests:
+#       storage: 5Gi


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
✨ Feature

## PR Description
This PR add K8s Manifest for services of Carrot Mapper app.

To run this K8s Manifest on local, you would need `Minikube` configured, then:
- Move to the parent folder of the `k8s` folder
- Run `kubectl create namespace carrot-mapper`
- Run `kubectl apply -f k8s --recursive` the check the K8s dashboard `minikube dashboard` to confirm all of the pods and deployments are up and running.
- Then `minikube tunnel` to expose Carrot's Airflow, API and Frontend.
- Access admin portal at `http://localhost:8000/admin/`, frontend at `http://localhost:3000` and Airflow at `http://localhost:8080`.
- To access DB: `kubectl port-forward svc/postgres-service 5432:5432 -n carrot-mapper`
- To access Minio: `kubectl port-forward svc/minio-service 9001:9001 -n carrot-mapper`

Note 1: In the real deployment, Omop Lite needs to load real vocabularies from its PVC, and the API service needs to depend on some sort of signal from OMOP LITE to know when it's finished to start. Otherwise, the concepts that can be added are limited, and migration conflicts can happen (can mitigate this by applying/deploying apps in order, though).

Note 2: The version of apps here is fixed to 3.1.0

## Related Issues or other material
Closes https://github.com/Health-Informatics-UoN/carrot-mapper/issues/1107

