### PR TITLE
Improved data requirement docs

### DIFF
--- a/website/src/pages/standards.mdx
+++ b/website/src/pages/standards.mdx
@@ -17,6 +17,7 @@ The CSV files must fulfil the following:
 - One or more CSV files that contain event data, such as questionnaire responses or clinical events/measurements. 
 - As a minimum each CSV file must have a column that contains the anonymised ID for the individual (matching an entry in the CSV file above), the date of a particular event (one per file) and one or more columns that capture the data relevant to that date. 
 - You can have as many CSV files as needed, but each CSV file must only contain information effective on the specified event date.
+- Where there are multiple mappings to the same output (i.e., the same OMOP table and field), all source headers for this mapping must be identical.
 - All measurements in the metric system.
 - All dates and datetimes in the ISO-8601 format: YYYY-MM-DD HH:MM:SS.ffffff
 - All numbers without any digit grouping symbols (e.g. 1000, not 1,000).

--- a/website/src/pages/transform/quickstart.mdx
+++ b/website/src/pages/transform/quickstart.mdx
@@ -51,7 +51,7 @@ If it doesn't exist, this directory should be created for you.
 |--------------------|------------------------------------------------|
 | `--input-dir`      | Directory containing input files               |
 | `--rules-file`     | JSON file with mapping rules                   |
-| `--person-file`    | CSV file where the first column contains person IDs |
+| `--person-file`    | CSV file where the first column contains person IDs. This is used as a registry for all valid person IDs. Person IDs not found in this registry will be omitted from all OMOP tables. This file can also be used as an input file, if it has additional data, and is located in the input directory. |
 | `--output-dir`     | Directory for OMOP-format TSV files            |
 
 


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
📝 Documentation

## PR Description
Note added to data requirements specifically covering mismatching of headers when data is split between files for a single omop target. 
Additional notes on the person file added, specifically about its role as a registry, what happens if person ids are not in it, and that it can also be used as a data input.

## Related Issues or other material
Related https://github.com/Health-Informatics-UoN/carrot-transform/issues/76, https://github.com/Health-Informatics-UoN/carrot-transform/issues/72
Closes https://github.com/Health-Informatics-UoN/carrot-transform/issues/77

## ✅ Added/updated tests?
- [X] This PR contains relevant tests / Or doesn't need to per the below explanation
Doc update, no tests required.

