### PR TITLE
Page size configuration documentation

### DIFF
--- a/samples/Carrot-Mapper/compose/mapper.compose.yml
+++ b/samples/Carrot-Mapper/compose/mapper.compose.yml
@@ -51,7 +51,6 @@ services:
 
   frontend:
     image: ghcr.io/health-informatics-uon/carrot/frontend:${RELEASE_VERSION}
-    command: node server.js
     ports:
       - 3000:3000
     environment:
@@ -63,9 +62,6 @@ services:
       NODE_ENV: development
       BODY_SIZE_LIMIT: 20971520
       NEXT_PUBLIC_ENABLE_REUSE_TRIGGER_OPTION: true
-    volumes:
-      - /app/node_modules
-      - /app/.next
     depends_on:
       api:
         condition: service_healthy

--- a/website/src/pages/mapper/deployment/configuration.mdx
+++ b/website/src/pages/mapper/deployment/configuration.mdx
@@ -524,3 +524,81 @@ By default, Carrot will **automatically create the necessary resources such as `
 - **BUCKETS** = [ `scan-reports`, `data-dictionaries`, `rules-exports` ]
 
 - **QUEUES** = [ `rules-local`, `rules-exports-local`, `uploadreports-local` ]
+
+## AI Recommendations (Lettuce & Unison)
+
+Carrot Mapper can use external AI services to search for OMOP concepts when mapping scan report values. Two providers are supported: Lettuce and Unison. This document describes how the feature works and how to configure it.
+
+## Overview
+
+For us to make use of the AI powered concept search feature, we need to either head to `scanreports/scanreports_id/tables/table_id/` or `scanreports/scanreports_id/tables/table_id/fields/field_id/` and click on the `Suggestions` button.
+This will open a modal with a list of AI suggestions.
+We click the `Suggestion` button to get a list of Domains from the AI service. We select the Suitable Domain, which will then open a modal with a list of OMOP concepts.
+We select the most suitable OMOP concept guided by the Accuracy/Score and click the "Add" button. The OMOP concept will be added to the field.
+
+
+**Environment variables**
+
+<Table>
+  <thead>
+    <Tr>
+      <Th>Variable</Th>
+      <Th>Required</Th>
+      <Th>Description</Th>
+    </Tr>
+  </thead>
+  <tbody>
+    <Tr>
+      <Td>`NEXT_PUBLIC_ENABLE_AI_RECOMMENDATION`</Td>
+      <Td>Yes (to show the feature)</Td>
+      <Td>Set to "true" to show the AI Suggestions column and button.</Td>
+    </Tr>
+    <Tr>
+      <Td>`NEXT_PUBLIC_RECOMMENDATION_SERVICE`</Td>
+      <Td>Yes (when AI recommendations are enabled)</Td>
+      <Td>Which provider to use: "lettuce" or "unison".</Td>
+    </Tr>
+    <Tr>
+      <Td>`RECOMMENDATION_SERVICE_BASE_URL`</Td>
+      <Td>Yes</Td>
+      <Td>Base URL of the recommendation API (e.g. Unison: https://api.hyperunison.com/api/public/suggester/generate).</Td>
+    </Tr>
+    <Tr>
+      <Td>`RECOMMENDATION_SERVICE_API_KEY`</Td>
+      <Td>Yes</Td>
+      <Td>API key for the service. Used as query parameter for Unison and as Bearer token for Lettuce.</Td>
+    </Tr>
+  </tbody>
+</Table>
+
+`NEXT_PUBLIC_*` variables are exposed to the browser; the API key and base URL are only used in server-side code (Next.js server actions).
+
+**Provider-specific behaviour**
+
+**Unison**
+
+- **URL:** Request is `GET {RECOMMENDATION_SERVICE_BASE_URL}/{queryValue}?apiKey={RECOMMENDATION_SERVICE_API_KEY}&domain={domainId}`.
+- **Auth:** API key is sent as the `apiKey` query parameter.
+- **Query:** Unison can be queried by concept name or concept code (exact match); concept code is typically tried first, then concept name.
+
+**Lettuce**
+
+- **URL:** Request is `GET {RECOMMENDATION_SERVICE_BASE_URL}/{queryValue}?domain={domainId}`.
+- **Auth:** API key is sent as `Authorization: Bearer {RECOMMENDATION_SERVICE_API_KEY}`.
+
+
+**Example: Docker Compose**
+
+The `docker-compose.yml` includes an example for Unison:
+
+```yaml
+environment:
+  - NEXT_PUBLIC_ENABLE_AI_RECOMMENDATION=true
+  - NEXT_PUBLIC_RECOMMENDATION_SERVICE=unison
+  - RECOMMENDATION_SERVICE_BASE_URL=https://api.hyperunison.com/api/public/suggester/generate
+  - RECOMMENDATION_SERVICE_API_KEY=unison-api-key
+```
+
+For Lettuce you would set `NEXT_PUBLIC_RECOMMENDATION_SERVICE=lettuce`, `RECOMMENDATION_SERVICE_BASE_URL` to your Lettuce endpoint, and `RECOMMENDATION_SERVICE_API_KEY` to your Lettuce API key.
+
+To enable AI Recommendations, (Lettuce/Unison) feature, set `NEXT_PUBLIC_ENABLE_AI_RECOMMENDATION=true`, and configure the four variables in the above docker-compose.yml file.

--- a/website/src/pages/mapper/deployment/configuration.mdx
+++ b/website/src/pages/mapper/deployment/configuration.mdx
@@ -404,7 +404,7 @@ Coming soon
       <Td>`EXECUTE_VALUES_PAGE_SIZE`</Td>
       <Td>
         Page size for bulk database inserts (Scan Report and Data Dictionary
-        uploads). Defaults to 1,000,000. See Bulk Insert Batch Size below for
+        uploads). Defaults to `1,000,000`. See Bulk Insert Batch Size below for
         when to change it.
       </Td>
     </Tr>

--- a/website/src/pages/mapper/deployment/configuration.mdx
+++ b/website/src/pages/mapper/deployment/configuration.mdx
@@ -601,4 +601,45 @@ environment:
 
 For Lettuce you would set `NEXT_PUBLIC_RECOMMENDATION_SERVICE=lettuce`, `RECOMMENDATION_SERVICE_BASE_URL` to your Lettuce endpoint, and `RECOMMENDATION_SERVICE_API_KEY` to your Lettuce API key.
 
-To enable AI Recommendations, (Lettuce/Unison) feature, set `NEXT_PUBLIC_ENABLE_AI_RECOMMENDATION=true`, and configure the four variables in the above docker-compose.yml file.
+To enable AI Recommendations, (Lettuce/Unison) feature, set `NEXT_PUBLIC_ENABLE_AI_RECOMMENDATION=true`, and configure the four variables in the above `docker-compose.yml` file.
+
+## Bulk Insert Batch Size
+
+When we upload a Scan Report or Data Dictionary, the Airflow DAG bulk inserts rows into temporary tables (`temp_data_dictionary_*` and `temp_field_values_*`). `EXECUTE_VALUES_PAGE_SIZE` controls how many rows go into each batch. 
+Bigger batches mean fewer round-trips to the database while smaller batches mean more round-trips but less memory per insert.
+
+The default is 1,000,000, which usually means one batch per table. If you have 44,000 records and set the page size to 10, you'll get about 4,400 batches instead.
+
+### Configuration
+
+It's an environment variable. Add it to the `airflow-scheduler` service in the `docker-compose.yml`:
+
+```yaml
+scheduler:
+    <<: *airflow-common
+    build:
+      context: app/airflow
+      dockerfile: Dockerfile
+      args:
+        AIRFLOW_COMPONENT: scheduler
+    environment:
+      <<: *airflow-common-env
+      ***other environment variables***
+
+      EXECUTE_VALUES_PAGE_SIZE: 1000000 # page size for bulk database inserts (execute_values)
+
+```
+
+If we don't set it, the default of 1,000,000 is used.
+
+### When to change it
+
+In most cases, we don't need to change this setting. The default batch size is already optimized for most environments.
+If we start running into memory issues or database timeouts, which may happen with large scan reports, try lowering the batch size to 100,000 or 50,000.
+For slow or unreliable networks, use smaller batch sizes (like 1,000–10,000) to reduce the risk if one fails, and to make inserts less likely to time out.
+On machines with limited memory, sticking with a batch size between 1,000 and 10,000 can help keep your memory usage low, but it may result in more trips to the database.
+
+### Code references
+
+- `app/airflow/dags/libs/settings.py` – reads the env var (default 1,000,000)
+- `app/airflow/dags/libs/SR_processing/db_services.py` – uses it for the bulk inserts

--- a/website/src/pages/mapper/deployment/configuration.mdx
+++ b/website/src/pages/mapper/deployment/configuration.mdx
@@ -573,7 +573,7 @@ We select the most suitable OMOP concept guided by the Accuracy/Score and click 
 
 `NEXT_PUBLIC_*` variables are exposed to the browser; the API key and base URL are only used in server-side code (Next.js server actions).
 
-**Provider-specific behaviour**
+**How each provider works**
 
 **Unison**
 

--- a/website/src/pages/mapper/deployment/configuration.mdx
+++ b/website/src/pages/mapper/deployment/configuration.mdx
@@ -400,8 +400,57 @@ Coming soon
         Credentials required to access the Airflow webserver and Airflow API.
       </Td>
     </Tr>
+    <Tr>
+      <Td>`EXECUTE_VALUES_PAGE_SIZE`</Td>
+      <Td>
+        Page size for bulk database inserts (Scan Report and Data Dictionary
+        uploads). Defaults to 1,000,000. See Bulk Insert Batch Size below for
+        when to change it.
+      </Td>
+    </Tr>
   </tbody>
 </Table>
+
+### Bulk Insert Batch Size
+
+When we upload a Scan Report or Data Dictionary, the Airflow DAG bulk inserts rows into temporary tables (`temp_data_dictionary_*` and `temp_field_values_*`). `EXECUTE_VALUES_PAGE_SIZE` controls how many rows go into each batch. 
+Bigger batches mean fewer round-trips to the database while smaller batches mean more round-trips but less memory per insert.
+
+The default is 1,000,000, which usually means one batch per table. If you have 44,000 records and set the page size to 10, you'll get about 4,400 batches instead.
+
+#### Configuration
+
+It's an environment variable. Add it to the `airflow-scheduler` service in the `docker-compose.yml`:
+
+```yaml
+scheduler:
+    <<: *airflow-common
+    build:
+      context: app/airflow
+      dockerfile: Dockerfile
+      args:
+        AIRFLOW_COMPONENT: scheduler
+    environment:
+      <<: *airflow-common-env
+      ***other environment variables***
+
+      EXECUTE_VALUES_PAGE_SIZE: 1000000 # page size for bulk database inserts (execute_values)
+
+```
+
+If we don't set it, the default of 1,000,000 is used.
+
+#### When to change it
+
+In most cases, we don't need to change this setting. The default batch size is already optimized for most environments.
+If we start running into memory issues or database timeouts, which may happen with large scan reports, try lowering the batch size to 100,000 or 50,000.
+For slow or unreliable networks, use smaller batch sizes (like 1,000–10,000) to reduce the risk if one fails, and to make inserts less likely to time out.
+On machines with limited memory, sticking with a batch size between 1,000 and 10,000 can help keep your memory usage low, but it may result in more trips to the database.
+
+#### Code references
+
+- `app/airflow/dags/libs/settings.py` – reads the env var (default 1,000,000)
+- `app/airflow/dags/libs/SR_processing/db_services.py` – uses it for the bulk inserts
 
 ## Other services
 
@@ -614,43 +663,3 @@ For Lettuce you would set `NEXT_PUBLIC_RECOMMENDATION_SERVICE=lettuce`, `RECOMME
 
 To enable AI Recommendations, (Lettuce/Unison) feature, set `NEXT_PUBLIC_ENABLE_AI_RECOMMENDATION=true`, and configure the four variables in the above `docker-compose.yml` file.
 
-## Bulk Insert Batch Size
-
-When we upload a Scan Report or Data Dictionary, the Airflow DAG bulk inserts rows into temporary tables (`temp_data_dictionary_*` and `temp_field_values_*`). `EXECUTE_VALUES_PAGE_SIZE` controls how many rows go into each batch. 
-Bigger batches mean fewer round-trips to the database while smaller batches mean more round-trips but less memory per insert.
-
-The default is 1,000,000, which usually means one batch per table. If you have 44,000 records and set the page size to 10, you'll get about 4,400 batches instead.
-
-### Configuration
-
-It's an environment variable. Add it to the `airflow-scheduler` service in the `docker-compose.yml`:
-
-```yaml
-scheduler:
-    <<: *airflow-common
-    build:
-      context: app/airflow
-      dockerfile: Dockerfile
-      args:
-        AIRFLOW_COMPONENT: scheduler
-    environment:
-      <<: *airflow-common-env
-      ***other environment variables***
-
-      EXECUTE_VALUES_PAGE_SIZE: 1000000 # page size for bulk database inserts (execute_values)
-
-```
-
-If we don't set it, the default of 1,000,000 is used.
-
-### When to change it
-
-In most cases, we don't need to change this setting. The default batch size is already optimized for most environments.
-If we start running into memory issues or database timeouts, which may happen with large scan reports, try lowering the batch size to 100,000 or 50,000.
-For slow or unreliable networks, use smaller batch sizes (like 1,000–10,000) to reduce the risk if one fails, and to make inserts less likely to time out.
-On machines with limited memory, sticking with a batch size between 1,000 and 10,000 can help keep your memory usage low, but it may result in more trips to the database.
-
-### Code references
-
-- `app/airflow/dags/libs/settings.py` – reads the env var (default 1,000,000)
-- `app/airflow/dags/libs/SR_processing/db_services.py` – uses it for the bulk inserts


### PR DESCRIPTION
📝 Documentation
## PR Description
This PR adds documentation to explain the use of EXECUTE_VALUES_PAGE_SIZE in carrot mapper. It illustrates how to set it and when to change it to suit the smooth running of mapper.

## Related Issues or other material
Related #119 
Closes #119 